### PR TITLE
メイン画像のアップロードと表示の実装

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,18 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+
+document.addEventListener('turbo:load', () => {
+  const swiper = new Swiper(".swiper-container", {
+    loop: true,
+    autoplay: false,
+    pagination: {
+      el: ".swiper-pagination",
+      clickable: true,
+    },
+    navigation: {
+      nextEl: ".swiper-button-next",
+      prevEl: ".swiper-button-prev",
+    },
+  });
+});

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,9 +1,12 @@
 class Post < ApplicationRecord
   # アソシエーション
   belongs_to :user
-  has_one_attached :thumbnail
+  has_one_attached :thumbnail, dependent: :destroy
+  has_many_attached :main_images, dependent: :destroy
 
   # バリデーション
   validates :title, presence: true, length: { maximum: 255 }
   validates :body, presence: true, length: { maximum: 65_535 }
+  validates :thumbnail, attachment: { content_type: %r{\Aimage/(png|jpeg)\Z}, maximum: 15.megabytes, purge: true }
+  validates :main_images, attachment: { content_type: %r{\Aimage/(png|jpeg)\Z}, maximum: 15.megabytes, purge: true }
 end

--- a/app/validators/attachment_validator.rb
+++ b/app/validators/attachment_validator.rb
@@ -1,0 +1,63 @@
+class AttachmentValidator < ActiveModel::EachValidator
+  include ActiveSupport::NumberHelper
+
+  def validate_each(record, attribute, value)
+    return if value.blank? || !value.attached?
+
+    has_error = false
+
+    if options[:maximum]
+      if value.is_a?(ActiveStorage::Attached::Many)
+        # 画像が複数枚投稿された場合
+        value.each do |v|
+          unless validate_maximum(record, attribute, v)
+            has_error = true
+            break
+          end
+        end
+      else
+        # 画像が1枚投稿された場合
+        has_error = true unless validate_maximum(record, attribute, value)
+      end
+    end
+
+    if options[:content_type]
+      if value.is_a?(ActiveStorage::Attached::Many)
+        # 画像が複数枚投稿された場合
+        value.each do |v|
+          unless validate_content_type(record, attribute, v)
+            has_error = true
+            break
+          end
+        end
+      else
+        # 画像が1枚投稿された場合
+        has_error = true unless validate_content_type(record, attribute, value)
+      end
+    end
+    
+    # エラーがあった場合にpurgeする
+    record.send(attribute).purge if options[:purge] && has_error
+  end
+
+  private
+
+  def validate_maximum(record, attribute, value)
+    puts "Validating maximum size for #{value.filename}"  # デバッグ情報を出力
+    if value.byte_size > options[:maximum]
+      record.errors.add(attribute, options[:message] || "は#{number_to_human_size(options[:maximum])}以下にしてください")
+      false
+    else
+      true
+    end
+  end
+
+  def validate_content_type(record, attribute, value)
+    if value.content_type.match?(options[:content_type])
+      true
+    else
+      record.errors.add(attribute, options[:message] || 'は対応できないファイル形式です')
+      false
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,9 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.css"/>
+    <script src="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.js"></script>
   </head>
 
   <body class="bg-gray-100">

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -17,5 +17,26 @@
     <%= f.file_field :thumbnail, class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
   </div>
 
+  <!-- メイン画像アップロードフィールド -->
+  <div class="mb-4">
+    <%= f.label :main_images, class: "block text-sm font-medium text-gray-700" %>
+    <%= f.file_field :main_images, multiple: true, class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
+  </div>
+
+  <!-- 画像の削除部分 -->
+  <% if post.main_images.attached? %>
+    <div class="flex flex-wrap">
+      <% post.main_images.each do |image| %>
+        <div class="w-1/4 p-2">
+          <%= image_tag image, class: 'object-cover w-full h-48' %>
+          <br>
+          <%= link_to t('images.delete.delete_link'), post_image_path(post, image.id), 
+                data: { turbo_method: 'delete', turbo_confirm: t('images.delete.confirmation') },
+                class: 'text-red-500 hover:text-red-700 cursor-pointer' %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
   <%= f.submit class: "w-full py-2 px-4 bg-blue-500 text-white font-semibold rounded-md hover:bg-blue-600" %>
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -7,7 +7,21 @@
       <%= @post.title %>
     </h4>
 
-    <!-- ここで複数画像の部分を削除 -->
+    <!-- Swiperスライダー表示部分 -->
+    <div class="swiper-container mb-4 relative  max-w-full overflow-hidden"> <!-- relativeクラスを追加 -->
+      <div class="swiper-wrapper">
+        <% @post.main_images.each do |image| %>
+          <div class="swiper-slide">
+            <%= image_tag image, class: "w-full rounded-md h-64 object-cover" %>
+          </div>
+        <% end %>
+      </div>
+      <!-- ページネーション（スライダー内に移動） -->
+      <div class="swiper-pagination absolute bottom-2 left-1/2 transform -translate-x-1/2"></div>
+      <!-- ナビゲーションボタン（スライダー内に移動） -->
+      <div class="swiper-button-prev absolute left-2 top-1/2 transform -translate-y-1/2"></div>
+      <div class="swiper-button-next absolute right-2 top-1/2 transform -translate-y-1/2"></div>
+    </div>
 
     <!-- 本文 -->
     <div class="mb-2 bg-gray-100 p-4 rounded-md">

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module Myapp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
 
+    # 複数画像の空の値が送信されないように
+    config.active_storage.multiple_file_field_include_hidden = false
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -13,4 +13,5 @@ ja:
         title: "タイトル"
         body: "内容"
         thumbnail: サムネ画像
+        main_images: メイン画像
         

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -24,6 +24,10 @@ ja:
       title: "記録の詳細画面"
     edit:
       title: "記録の編集画面"
+  images:
+      delete:
+        confirmation: "本当に削除しますか？"
+        delete_link: "削除"
   header:
     login: ログイン
     logout: ログアウト
@@ -45,3 +49,7 @@ ja:
         failure: "ログインに失敗しました。"
       destroy:
         success: "ログアウトしました。"
+    images:
+      delete:
+        success: "画像を削除しました"
+        failure: "画像の削除に失敗しました"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  resources :posts
+  resources :posts do
+    delete 'image/:id', to: 'posts#destroy_image', as: 'image'
+  end
   resources :users
   get "login", to: "user_sessions#new"
   post "login", to: "user_sessions#create"


### PR DESCRIPTION
## 概要
複数画像のアップロード機能の実装

### 主な内容
- メイン画像のアップロードフォームの作成(ActiveStorage)
- フォームでの個別の画像削除機能の実装
- カスタムバリデーションの実装
- swiperでのUIの作成（cdn）